### PR TITLE
Implement support for calling different diff tools.

### DIFF
--- a/source/OpenFilesDialog.h
+++ b/source/OpenFilesDialog.h
@@ -65,6 +65,7 @@ private:
 	{
 		dtInternal = 0,
 		dtPe,
+		dtMcDiff,
 		dtKdiff3,
 		dtVimDiff
 	};
@@ -75,6 +76,9 @@ private:
 	void				doDiffThem();
 	void				populateDiffToolMenu();
 	int					getSelectedDiffTool();
+	void				setSelectedDiffTool(int diffTool);
+	void				readSettings();
+	status_t			writeSettings();
 
 private:
 	BFilePanel*			filePanels[FileMAX];	///< ファイルを選択するためのファイルパネル


### PR DESCRIPTION
This is a first, rough attempt, at implementing support for different diff utilities. Current options are:

 - Internal
 - Pe "diff mode" (needs Pe's [PR #85](https://github.com/HaikuArchives/Pe/pull/85))
 - mcdiff
 - kdiff3 (untested)
 - vimdiff ~(untested)~

Defaults to Internal ~for now, until saving/restore settings gets implemented.~, but remembers last selected choice.

Opening this as a Draft, as to gather some feedback, to see if this sounds more or less OK, or I'm missing the mark by too much.

I guess we could allow adding custom diff tools by reading "tool_name=cmd_line %file1 %file2" or similar from a settings file. For now, mostly due to my limited skills (and short attention spans)... that will be left out as an "exercise for the reader" :-)

Preview (from before `mcdiff` was added):
![PonpokoDiff](https://user-images.githubusercontent.com/923213/209497455-8085e34e-eab8-4967-af06-bcd6123204bf.png)
