### PR TITLE
Node-monitor both files and reload on change

### DIFF
--- a/source/OpenFilesDialog.cpp
+++ b/source/OpenFilesDialog.cpp
@@ -285,7 +285,7 @@ OpenFilesDialog::doDiffThem()
 
 	PonpokoDiffApp* app = static_cast<PonpokoDiffApp*>(be_app);
 	TextDiffWnd* newDiffWnd = app->NewTextDiffWnd();
-	newDiffWnd->ExecuteDiff(leftPath, rightPath, NULL, NULL);
+	newDiffWnd->ExecuteDiff(leftPath, rightPath);
 	PostMessage(B_QUIT_REQUESTED);
 }
 

--- a/source/PonpokoDiffApp.h
+++ b/source/PonpokoDiffApp.h
@@ -60,7 +60,6 @@ public:
 private:
 			void			makeNewTextDiffWndRect(BRect& frameRect);
 			void			doOpenFileDialog();
-			void			makeVersionString(BString& versionString);
 
 private:
 		int32				textDiffWndCount;		///< 動作している TextDiffWnd の数

--- a/source/TextDiffView.cpp
+++ b/source/TextDiffView.cpp
@@ -312,12 +312,10 @@ public:
  *	@brief	Diff を実行します。
  *	@param[in]	pathLeft	左ペインに表示するファイルのパス
  *	@param[in]	pathRight	右ペインに表示するファイルのパス
- *	@param[in]	labelLeft	左ペインに表示するファイルのラベル (NULL ならパス名を使います)
- *	@param[in]	labelRight	右ペインに表示するファイルのラベル (NULL ならパス名を使います)
  */
 void
 TextDiffView::ExecuteDiff(
-	const BPath& pathLeft, const BPath& pathRight, const char* labelLeft, const char* labelRight)
+	const BPath& pathLeft, const BPath& pathRight)
 {
 	// 初期化
 	textData[LeftPane].Unload();

--- a/source/TextDiffView.h
+++ b/source/TextDiffView.h
@@ -51,8 +51,7 @@ public:
 	virtual				~TextDiffView();
 
 			void		Initialize();
-			void		ExecuteDiff(const BPath& pathLeft, const BPath& pathRight,
-							const char* labelLeft, const char* labelRight);
+			void		ExecuteDiff(const BPath& pathLeft, const BPath& pathRight);
 
 public:
 	virtual	void		FrameResized(float width, float height);

--- a/source/TextDiffWnd.h
+++ b/source/TextDiffWnd.h
@@ -50,8 +50,7 @@ public:
 
 			void			Initialize();
 
-			void			ExecuteDiff(const BPath& pathLeft, const BPath& pathRight,
-								const char* labelLeft, const char* labelRight);
+			void			ExecuteDiff(const BPath& pathLeft, const BPath& pathRight);
 
 public:
 	virtual	void			Quit();
@@ -59,11 +58,18 @@ public:
 
 private:
 			void			createMainMenu(BMenuBar* menuBar);
+			void			startNodeMonitor();
+			void			handleNodeMonitorEvent(BMessage* message);
+			void			askToReload(node_ref nref_node);
+			void			updateTitle();
 			void			doFileOpen();
 			void			doFileQuit();
 
 			BPath			fPathLeft;
 			BPath			fPathRight;
+			node_ref 		fLeftNodeRef;
+			node_ref 		fRightNodeRef;
+
 			const char*		fLabelLeft;
 			const char*		fLabelRight;
 };

--- a/source/locales/en.catkeys
+++ b/source/locales/en.catkeys
@@ -1,17 +1,22 @@
-1	English	application/x-vnd.Hironytic-PonpokoDiff	1584786771
+1	English	application/x-vnd.Hironytic-PonpokoDiff	1017592319
+Cancel	TextDiffWindow		Cancel
 Right file:	OpenFilesDialog		Right file:
 PonpokoDiff	System name		PonpokoDiff
 File	TextDiffWindow		File
 Close	TextDiffWindow		Close
 Select left file	OpenFilesDialog		Select left file
 A graphical file comparison utility.	Application		A graphical file comparison utility.
+Do you want to reload the files and diff them again?	TextDiffWindow		Do you want to reload the files and diff them again?
+A file has changed	TextDiffWindow		A file has changed
 Reload	TextDiffWindow		Reload
 Left file:	OpenFilesDialog		Left file:
 Cancel	OpenFilesDialog		Cancel
 Select right file	OpenFilesDialog		Select right file
+The left file, %filename%, has changed.	TextDiffWindow		The left file, %filename%, has changed.
 PonpokoDiff: Open files	OpenFilesDialog		PonpokoDiff: Open files
 Open…	TextDiffWindow		Open…
 Diff	OpenFilesDialog		Diff
 Browse…	OpenFilesDialog		Browse…
 About PonpokoDiff	TextDiffWindow		About PonpokoDiff
 Quit	TextDiffWindow		Quit
+The right file, %filename%, has changed.	TextDiffWindow		The right file, %filename%, has changed.


### PR DESCRIPTION
* Only modification time is considered, that is changes in file content. Then you get a BAlert asking to reload + diff.

  If a file was moved or renamed, keep track of it, but don't bother the user with an alert

* Remove the "L" label command line parameter. I can't see the use of it. Remove the label member variables, use e.g. fLeftPath.Path() when needed.