### PR TITLE
Add Norwegian and Spanish (LA) translations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,47 @@
+
+# Created by https://www.gitignore.io/api/c++,vim
+
+*.d
+objects*/
+source/objects*/
+PonpokoDiff
+
+### C++ ###
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+
+### Vim ###
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+*.un~
+Session.vim
+.netrwhist
+*~
+

--- a/source/Makefile
+++ b/source/Makefile
@@ -92,7 +92,7 @@ OPTIMIZE :=
 # 	will recreate only the "locales/en.catkeys" file. Use it as a template
 # 	for creating catkeys for other languages. All localization files must be
 # 	placed in the "locales" subdirectory.
-LOCALES = de en
+LOCALES = de en es-419 nb
 
 #	Specify all the preprocessor symbols to be defined. The symbols will not
 #	have their values set automatically; you must supply the value (if any) to

--- a/source/locales/es-419.catkeys
+++ b/source/locales/es-419.catkeys
@@ -1,0 +1,22 @@
+1	Spanish (Latin American)	application/x-vnd.Hironytic-PonpokoDiff	1017592319
+A file has changed	TextDiffWindow		Un archivo ha cambiado
+About PonpokoDiff	TextDiffWindow		Sobre PonpokoDiff
+Cancel	TextDiffWindow		Cancelar
+Close	TextDiffWindow		Cerrar
+Do you want to reload the files and diff them again?	TextDiffWindow		¿Quieres volver a cargar los archivos y compararlos nuevamente?
+File	TextDiffWindow		Archivo
+Open…	TextDiffWindow		Abrir…
+Quit	TextDiffWindow		Salir
+Reload	TextDiffWindow		Volver a cargar
+The left file, %filename%, has changed.	TextDiffWindow		El archivo izquierdo, %filename%, ha cambiado.
+The right file, %filename%, has changed.	TextDiffWindow		El archivo derecho, %filename%, ha cambiado.
+A graphical file comparison utility.	Application		Una herramienta gráfica de comparación de archivos.
+Browse…	OpenFilesDialog		Navegar…
+Cancel	OpenFilesDialog		Cancelar
+Diff	OpenFilesDialog		Diff
+Left file:	OpenFilesDialog		Archivo izquierdo:
+PonpokoDiff: Open files	OpenFilesDialog		PonpokoDiff: Abrir archivos
+Right file:	OpenFilesDialog		Archivo derecho:
+Select left file	OpenFilesDialog		Seleccionar archivo izquierdo
+Select right file	OpenFilesDialog		Seleccionar archivo derecho
+PonpokoDiff	System name		PonpokoDiff

--- a/source/locales/nb.catkeys
+++ b/source/locales/nb.catkeys
@@ -1,0 +1,22 @@
+1	Norwegian	application/x-vnd.Hironytic-PonpokoDiff	1017592319
+A file has changed	TextDiffWindow		En fil er endret
+About PonpokoDiff	TextDiffWindow		Om PonpokoDiff
+Cancel	TextDiffWindow		Avbryt
+Close	TextDiffWindow		Lukk
+Do you want to reload the files and diff them again?	TextDiffWindow		Vil du laste inn filene på nytt og sammenligne dem igjen?
+File	TextDiffWindow		Fil
+Open…	TextDiffWindow		Åpne…
+Quit	TextDiffWindow		Avslutt
+Reload	TextDiffWindow		Last på nytt
+The left file, %filename%, has changed.	TextDiffWindow		Den venstre filen, %filename%, er endret.
+The right file, %filename%, has changed.	TextDiffWindow		Den høyre filen, %filename%, er endret.
+A graphical file comparison utility.	Application		Et grafisk verktøy for å sammenligne filer.
+Browse…	OpenFilesDialog		Bla gjennom…
+Cancel	OpenFilesDialog		Avbryt
+Diff	OpenFilesDialog		Diff
+Left file:	OpenFilesDialog		Venstre fil:
+PonpokoDiff: Open files	OpenFilesDialog		PonpokoDiff: Åpne filer
+Right file:	OpenFilesDialog		Høyre fil:
+Select left file	OpenFilesDialog		Velg venstre fil
+Select right file	OpenFilesDialog		Velg høyre fil
+PonpokoDiff	System name		PonpokoDiff


### PR DESCRIPTION
I completed the Norwegian (nb) and Spanish (Latin American) translations, and made an attempt to include them in the build. 

Not sure if it is correct. The translations are not picked up when I build the project using `make`, unless I go through the steps [outlined in the forum](https://discuss.haiku-os.org/t/testing-translations-without-compiling-an-app/9351?u=johan). Is that expected, or am I missing something?

In addition, the Spanish translation is not picked up when the file is called `es-419.catalog`, (in the folder `~/config/non-packaged/...`) and Haiku Locale is set to Spanish (Latin American). Only when I rename the file to `es.catalog` does it work.