### PR TITLE
Monitor removal of files, too

### DIFF
--- a/source/PonpokoDiffApp.cpp
+++ b/source/PonpokoDiffApp.cpp
@@ -161,7 +161,7 @@ PonpokoDiffApp::TextDiffWndQuit(TextDiffWnd* /* wnd */)
 	BAutolock locker(this);
 	if (locker.IsLocked()) {
 		textDiffWndCount--;
-		if (textDiffWndCount <= 0)
+		if (textDiffWndCount <= 0 && openFilesDialog == NULL)
 			PostMessage(B_QUIT_REQUESTED);
 	}
 }
@@ -184,8 +184,14 @@ PonpokoDiffApp::MessageReceived(BMessage* message)
 {
 	switch (message->what) {
 		case ID_FILE_OPEN:
+		{
 			doOpenFileDialog();
-			break;
+
+			BMessenger window;
+			if (message->FindMessenger("killme", &window) == B_OK)
+				window.SendMessage(new BMessage(B_QUIT_REQUESTED));
+
+		} break;
 
 		default:
 			BApplication::MessageReceived(message);

--- a/source/TextDiffWnd.h
+++ b/source/TextDiffWnd.h
@@ -37,7 +37,8 @@ private:
 			void			createMainMenu(BMenuBar* menuBar);
 			void			startNodeMonitor();
 			void			handleNodeMonitorEvent(BMessage* message);
-			void			askToReload(node_ref nref_node);
+			void			askToReload(node_ref nref);
+			void			askFileRemoved(node_ref nref);
 			void			openFile(BPath path);
 
 			void			updateTitle();

--- a/source/locales/en.catkeys
+++ b/source/locales/en.catkeys
@@ -1,22 +1,28 @@
-1	English	application/x-vnd.Hironytic-PonpokoDiff	1017592319
+1	English	application/x-vnd.Hironytic-PonpokoDiff	994275366
 Cancel	TextDiffWindow		Cancel
 Right file:	OpenFilesDialog		Right file:
-PonpokoDiff	System name		PonpokoDiff
-File	TextDiffWindow		File
-Close	TextDiffWindow		Close
-Select left file	OpenFilesDialog		Select left file
-A graphical file comparison utility.	Application		A graphical file comparison utility.
 Do you want to reload the files and diff them again?	TextDiffWindow		Do you want to reload the files and diff them again?
-A file has changed	TextDiffWindow		A file has changed
 Reload	TextDiffWindow		Reload
+A file has changed	TextDiffWindow		A file has changed
 Left file:	OpenFilesDialog		Left file:
-Cancel	OpenFilesDialog		Cancel
-Select right file	OpenFilesDialog		Select right file
-The left file, %filename%, has changed.	TextDiffWindow		The left file, %filename%, has changed.
+Do you want to diff two new files, or just ignore this?	TextDiffWindow		Do you want to diff two new files, or just ignore this?
 PonpokoDiff: Open files	OpenFilesDialog		PonpokoDiff: Open files
 Open…	TextDiffWindow		Open…
+A file has disappeared	TextDiffWindow		A file has disappeared
 Diff	OpenFilesDialog		Diff
+Quit	TextDiffWindow		Quit
+The right file, '%filename%', has changed.	TextDiffWindow		The right file, '%filename%', has changed.
+PonpokoDiff	System name		PonpokoDiff
+File	TextDiffWindow		File
+Select left file	OpenFilesDialog		Select left file
+Close	TextDiffWindow		Close
+A graphical file comparison utility.	Application		A graphical file comparison utility.
+The left file, '%filename%', has changed.	TextDiffWindow		The left file, '%filename%', has changed.
+The left file, '%filename%', has disappeared. Probably it was deleted or moved to another volume.	TextDiffWindow		The left file, '%filename%', has disappeared. Probably it was deleted or moved to another volume.
+Cancel	OpenFilesDialog		Cancel
+Diff new files	TextDiffWindow		Diff new files
+Select right file	OpenFilesDialog		Select right file
+Ignore	TextDiffWindow		Ignore
 Browse…	OpenFilesDialog		Browse…
 About PonpokoDiff	TextDiffWindow		About PonpokoDiff
-Quit	TextDiffWindow		Quit
-The right file, %filename%, has changed.	TextDiffWindow		The right file, %filename%, has changed.
+The right file, '%filename%', has disappeared. Probably it was deleted or moved to another volume.	TextDiffWindow		The right file, '%filename%', has disappeared. Probably it was deleted or moved to another volume.


### PR DESCRIPTION
If a file disappears (deleted or moved to a different volume), pop up an alert to either ignore this or call the OpenFileDialog to diff two new files.

Updated en.catkeys.

When calling the OpenFileDialog, add our calling window to the BMessege and have it quit our window _after_ showing the OpenFileDialog. Otherwise the whole app will quit when there are no windows left around...